### PR TITLE
Stop breaking in Webpack 2

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -103,7 +103,7 @@ module.exports = class IconPlugin {
       require.resolve('./loader'),
       // TODO(Jeremy):
       // SVGO loader to optimize assets, or allow passing in a loader.
-      'svg-sprite?extract=true',
+      'svg-sprite-loader?extract=true',
     ].join('!');
   }
 


### PR DESCRIPTION
This isn't full support for webpack 2, but it at least allows it to be used with the legacy `loader` syntax.

This gets us to at least a usable state with #3.